### PR TITLE
Version 1.1.0 - Enum Extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.0] - 2024-04-08
+
+### Added
+
+- a new `enum_eval` method that turns any reasonable value into an instance 
+  of the supplied Enum class _(i.e. string names or ints or whatever)_.
+- a new enum base class, `EnumEx` that extends `enum.Enum` by adding a 
+  `from_any` class method that uses `enum_eval` to initialize a new instance 
+  of whatever class extends `EnumEx` from any sensible value
+- the new `EnumEx` class to the base `ccptools.structs` import
+
+### Changed
+
+- how `int_eval` tries to cast strings and bytes since failed try/except's 
+  are much faster than evaluating the content of a string first
+
+
 ## [1.0.0] - 2024-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,8 +103,11 @@ TimeZone = datetime.timezone
 ```
 
 Furthermore, it'll also include a few of the most commonly used utility 
-classes from the Type Utils submodule, the `Singleton` Meta Class and the 
-`Empty` and `EmptyDict` classes as well as the `if_empty` method.
+classes from the Type Utils submodule:
+
+- The `Singleton` Meta Class 
+- The `Empty` and `EmptyDict` classes as well as the `if_empty` method
+- The `EnumEx` base class for Enums with the `from_any` class method
 
 So in most cases we can cover something like 90% of any imports we tend to 
 need in every Python file with a single line:

--- a/ccptools/__init__.py
+++ b/ccptools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/ccptools/structs/__init__.py
+++ b/ccptools/structs/__init__.py
@@ -2,5 +2,6 @@ from ccptools.structs._base import *
 
 from ccptools.tpu.structs.empty import *
 from ccptools.tpu.structs.singleton import *
+from ccptools.tpu.structs.enumex import *
 
 from ccptools.dtu.structs.aliases import *

--- a/ccptools/tpu/structs/enumex/__init__.py
+++ b/ccptools/tpu/structs/enumex/__init__.py
@@ -1,0 +1,1 @@
+from ._enumextra import *

--- a/ccptools/tpu/structs/enumex/_enumextra.py
+++ b/ccptools/tpu/structs/enumex/_enumextra.py
@@ -1,0 +1,25 @@
+__all__ = [
+    'EnumEx',
+]
+
+import enum
+from typing import *
+
+_T_ENUM = TypeVar('_T_ENUM', bound='EnumEx')
+
+_NOT_SUPPLIED = object()
+
+
+class EnumEx(enum.Enum):
+    @classmethod
+    def from_any(cls: Type[_T_ENUM], value: Any,
+                 default: Union[_T_ENUM, None] = _NOT_SUPPLIED) -> _T_ENUM:
+        """Casts any sensible value to an Enum of this type.
+
+        :param value: The value to cast to an Enum
+        :param default: Default value to return on failed eval if any. Defaults
+                        to _NOT_SUPPLIED and makes this method raise an
+                        exception on failure
+        """
+        from ccptools.tpu.casting import enum_eval
+        return enum_eval(value, cls, default=default, raise_on_fail=(default is _NOT_SUPPLIED))

--- a/tests/typeutils/test_eval_enum.py
+++ b/tests/typeutils/test_eval_enum.py
@@ -1,0 +1,68 @@
+import unittest
+
+from ccptools.tpu import casting
+import enum
+
+from ccptools.tpu.structs.enumex._enumextra import EnumEx
+
+
+class TestEnumEval(unittest.TestCase):
+    def test_enum_eval(self):
+        class SomeEnum(enum.Enum):
+            ALPHA = 0
+            BETA = 1
+            DELTA = 2
+
+        class OtherEnum(enum.Enum):
+            ONE = 1
+            TWO = 2
+            THREE = 3
+
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval('ALPHA', SomeEnum))
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval('Alpha', SomeEnum))
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval('alPHa ', SomeEnum))
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval('0 ', SomeEnum))
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval(0, SomeEnum))
+        self.assertEqual(SomeEnum.ALPHA, casting.enum_eval('Yomama', SomeEnum, SomeEnum.ALPHA))
+        self.assertIsNone(casting.enum_eval('Yomama', SomeEnum, None))
+
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval('DELTA', SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval('Delta', SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval(' DeLtA  ', SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval('2 ', SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval('0b10', SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval(0b10, SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval(2, SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval(OtherEnum.TWO, SomeEnum))
+        self.assertEqual(SomeEnum.DELTA, casting.enum_eval('Yomama', SomeEnum, SomeEnum.DELTA))
+        self.assertIsNone(casting.enum_eval('Yomama', SomeEnum, None))
+
+    def test_enum_ex(self):
+        class SomeEnum(EnumEx):
+            ALPHA = 0
+            BETA = 1
+            DELTA = 2
+
+        class OtherEnum(EnumEx):
+            ONE = 1
+            TWO = 2
+            THREE = 3
+
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any('ALPHA'))
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any('Alpha'))
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any('alPHa '))
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any('0 '))
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any(0))
+        self.assertEqual(SomeEnum.ALPHA, SomeEnum.from_any('Yomama', SomeEnum.ALPHA))
+        self.assertIsNone(SomeEnum.from_any('Yomama', None))
+
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any('DELTA'))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any('Delta'))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any(' DeLtA  '))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any('2 '))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any('0b10'))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any(0b10))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any(2))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any(OtherEnum.TWO))
+        self.assertEqual(SomeEnum.DELTA, SomeEnum.from_any('Yomama', SomeEnum.DELTA))
+        self.assertIsNone(SomeEnum.from_any('Yomama', None))


### PR DESCRIPTION
## [1.1.0] - 2024-04-08

### Added

- a new `enum_eval` method that turns any reasonable value into an instance of the supplied Enum class _(i.e. string names or ints or whatever)_.
- a new enum base class, `EnumEx` that extends `enum.Enum` by adding a `from_any` class method that uses `enum_eval` to initialize a new instance of whatever class extends `EnumEx` from any sensible value
- the new `EnumEx` class to the base `ccptools.structs` import